### PR TITLE
fix post message issue with async and await

### DIFF
--- a/client/src/store/utils/thunkCreators.js
+++ b/client/src/store/utils/thunkCreators.js
@@ -93,9 +93,9 @@ const sendMessage = (data, body) => {
 
 // message format to send: {recipientId, text, conversationId}
 // conversationId will be set to null if its a brand new conversation
-export const postMessage = (body) => (dispatch) => {
+export const postMessage = (body) => async (dispatch) => {
   try {
-    const data = saveMessage(body);
+    const data = await saveMessage(body);
 
     if (!body.conversationId) {
       dispatch(addConversation(body.recipientId, data.message));


### PR DESCRIPTION
Since saveMessage is async but postMessage isn't, the returned promise is ignored before dispatching to the store. The message data was undefined as the promise doesn't have it as a property. But after making postMessage async and awaiting the response, it fixes it.

Added async and await to postMessage function in thunkCreators. 